### PR TITLE
fix Ruby 3 build with the NetBSD community patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,21 @@ Contents
 =========
 
 c/
+
     Ferret is written in C for speed. The actual C code should be fairly easy
     to use in an application or create bindings to a language other than Ruby.
 
 ruby/
+
     This directory contains the Ruby bindings and tests. See ruby/README.md for
     information on installing Ferret's Ruby bindings
+
+Instructions
+============
+
+* Build the gem: `cd ruby && rake gem`
+* Publish the gem on github: see [RubyGems registry docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry)
+* Use in Gemfile: `gem "ferret", "0.11.9.0", source: "https://rubygems.pkg.github.com/acavalin"`
 
 Contributions
 =============

--- a/c/include/config.h
+++ b/c/include/config.h
@@ -17,7 +17,9 @@ extern "C" {
 #endif
 
 #ifndef __cplusplus
+#ifndef bool
 typedef unsigned int        bool;
+#endif
 #endif
 typedef unsigned char       frt_uchar;
 

--- a/c/include/index.h
+++ b/c/include/index.h
@@ -592,7 +592,7 @@ typedef struct FrtLazyDocField
     FrtLazyDoc          *doc;
     int                 size; /* number of data elements */
     int                 len;  /* length of data elements concatenated */
-    bool                is_compressed : 2; /* set to 2 after all data is loaded */
+    int                 is_compressed : 2; /* set to 2 after all data is loaded */
 } FrtLazyDocField;
 
 extern char *frt_lazy_df_get_data(FrtLazyDocField *self, int i);

--- a/c/src/q_boolean.c
+++ b/c/src/q_boolean.c
@@ -1528,7 +1528,7 @@ static int  bq_eq(Query *self, Query *o)
     BooleanQuery *bq1 = BQ(self);
     BooleanQuery *bq2 = BQ(o);
     if ((bq1->coord_disabled != bq2->coord_disabled)
-        || (bq1->max_clause_cnt != bq1->max_clause_cnt)
+        || (bq1->max_clause_cnt != bq2->max_clause_cnt)
         || (bq1->clause_cnt != bq2->clause_cnt)) {
         return false;
     }

--- a/c/src/q_span.c
+++ b/c/src/q_span.c
@@ -2254,7 +2254,7 @@ static int spanxq_eq(Query *self, Query *o)
 Query *spanxq_new_nr(Query *inc, Query *exc)
 {
     Query *self;
-    if (SpQ(inc)->field != SpQ(inc)->field) {
+    if (SpQ(inc)->field != SpQ(exc)->field) {
         RAISE(ARG_ERROR, "All clauses in a SpanQuery must have the same field. "
               "Attempted to add a SpanQuery with field \"%s\" along with a "
               "SpanQuery with field \"%s\" to an SpanNotQuery",

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -83,8 +83,10 @@ namespace :build do
     dest_fn = EXT_SRC_MAP[fn]
     # prepend lib files to avoid conflicts
     file dest_fn => fn do |t|
-      ln_sf File.expand_path(fn), File.expand_path(dest_fn)
-
+      dest_path = File.expand_path(dest_fn)
+      rm_f dest_path
+      cp File.expand_path(fn), dest_path
+      
       if fn =~ /stemmer/
         # flatten the directory structure for lib_stemmer
         open(dest_fn) do |in_f|

--- a/ruby/ext/ferret.h
+++ b/ruby/ext/ferret.h
@@ -72,7 +72,7 @@ extern char *rs2s(VALUE rstr);
 extern char *rstrdup(VALUE rstr);
 extern Symbol rintern(VALUE rstr);
 #define Frt_Make_Struct(klass)\
-  rb_data_object_alloc(klass,NULL,(RUBY_DATA_FUNC)NULL,(RUBY_DATA_FUNC)NULL)
+  rb_data_object_wrap(klass,NULL,(RUBY_DATA_FUNC)NULL,(RUBY_DATA_FUNC)NULL)
 
 #define Frt_Wrap_Struct(self,mmark,mfree,mdata)\
   do {\

--- a/ruby/lib/ferret/version.rb
+++ b/ruby/lib/ferret/version.rb
@@ -1,3 +1,3 @@
 module Ferret
-  VERSION = '0.11.8.7'
+  VERSION = '0.11.9.0'
 end


### PR DESCRIPTION
* fixed the compilation error with ruby 3: [issue](https://github.com/dbalmain/ferret/issues/14), [patch](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/textproc/ruby-ferret/patches/)
* fixed the gem build process: [patch](https://github.com/jkraemer/ferret/commit/903e5def137b28ce699a233d24712e07839bcf96)